### PR TITLE
[FE] FEAT: 로비 유저 프로필에 최근전적 버튼을 내정보 버튼으로 변경 #37

### DIFF
--- a/frontend/src/components/atoms/Button/Button.tsx
+++ b/frontend/src/components/atoms/Button/Button.tsx
@@ -44,15 +44,31 @@ const ButtonStyled = styled.button.attrs((props) => {
   }
 `;
 
-const Button = ({ children, to, ...rest }: Props) => {
+interface LinkWrapperProps {
+  width: string;
+  height: string;
+}
+
+const LinkWrapper = styled(Link)<LinkWrapperProps>`
+  width: ${(props) => props.width};
+  height: ${(props) => props.height};
+`;
+
+const Button = ({ children, to, width, height, ...rest }: Props) => {
   if (to) {
     return (
-      <Link to={to}>
-        <ButtonStyled {...rest}>{children}</ButtonStyled>
-      </Link>
+      <LinkWrapper height={height} width={width} to={to}>
+        <ButtonStyled width="100%" height="100%" {...rest}>
+          {children}
+        </ButtonStyled>
+      </LinkWrapper>
     );
   }
-  return <ButtonStyled {...rest}>{children}</ButtonStyled>;
+  return (
+    <ButtonStyled width={width} height={height} {...rest}>
+      {children}
+    </ButtonStyled>
+  );
 };
 
 export default Button;

--- a/frontend/src/components/modules/LobbyUserProfile/LobbyUserProfile.tsx
+++ b/frontend/src/components/modules/LobbyUserProfile/LobbyUserProfile.tsx
@@ -1,11 +1,13 @@
-import React from "react";
+import React, { useState } from "react";
 import styled from "styled-components";
 import Avatar from "../../atoms/Avatar";
 import Board from "../../atoms/Board";
 import Button from "../../atoms/Button";
+import ModalWrapper from "../../atoms/ModalWrapper";
 import Typography from "../../atoms/Typography";
 import ButtonGroup from "../ButtonGroup";
 import LogoutButton from "../LogoutButton";
+import UserInfoModal from "../UserInfoModal";
 
 const LobbyUserProfileStyled = styled(Board).attrs((props) => {
   return {
@@ -37,38 +39,53 @@ const Wrapper = styled(Board).attrs({
 
 // TODO: Logout api 추가
 const LobbyUserProfile = () => {
+  const [isOpenUserInfo, setOpenUserInfo] = useState(false);
+  const onOpenMenuDetail = () => {
+    setOpenUserInfo(true);
+  };
+  const onCloseMenuDetail = () => {
+    setOpenUserInfo(false);
+  };
+
   return (
-    <LobbyUserProfileStyled>
-      <LogoutButton to="/" />
-      <Avatar width={"10rem"} height={"10rem"} />
-      <UserInfo>
-        <Wrapper>
-          <Typography fontSize="1.5rem">user1</Typography>
-          <Typography fontSize="1.5rem">2승 2패 (50%)</Typography>
-          <Typography fontSize="1.5rem">1020 점</Typography>
-        </Wrapper>
-        <ButtonGroup height="30%" width="100%" justifyContent="space-between">
-          <Button
-            width="7vw"
-            height="5vh"
-            boxShadow
-            to="/ranking"
-            fontSize="1.5rem"
-          >
-            랭킹
-          </Button>
-          <Button
-            width="7vw"
-            height="5vh"
-            boxShadow
-            to="/stat/1"
-            fontSize="1.5rem"
-          >
-            최근전적
-          </Button>
-        </ButtonGroup>
-      </UserInfo>
-    </LobbyUserProfileStyled>
+    <>
+      <LobbyUserProfileStyled>
+        <LogoutButton to="/" />
+        <Avatar width={"10rem"} height={"10rem"} />
+        <UserInfo>
+          <Wrapper>
+            <Typography fontSize="1.5rem">user1</Typography>
+            <Typography fontSize="1.5rem">2승 2패 (50%)</Typography>
+            <Typography fontSize="1.5rem">1020 점</Typography>
+          </Wrapper>
+          <ButtonGroup height="30%" width="100%" justifyContent="space-between">
+            <Button
+              width="7vw"
+              height="5vh"
+              boxShadow
+              fontSize="1.5rem"
+              onClick={onOpenMenuDetail}
+            >
+              내정보
+            </Button>
+            <Button
+              width="7vw"
+              height="5vh"
+              boxShadow
+              to="/ranking"
+              fontSize="1.5rem"
+            >
+              랭킹
+            </Button>
+          </ButtonGroup>
+        </UserInfo>
+      </LobbyUserProfileStyled>
+      {isOpenUserInfo && (
+        <ModalWrapper onClose={onCloseMenuDetail}>
+          <UserInfoModal onClose={onCloseMenuDetail} width="50%" height="90%" />
+        </ModalWrapper>
+      )}
+    </>
   );
 };
 

--- a/frontend/src/components/modules/LogoutButton/LogoutButton.tsx
+++ b/frontend/src/components/modules/LogoutButton/LogoutButton.tsx
@@ -12,22 +12,19 @@ const LogoutLogo = styled(Logo)`
   height: 100%;
 `;
 
-const LogoutButtonStyled = styled(Button).attrs((props) => {
-  return {
-    width: "3.5%",
-    height: "4.5%",
-    backgroundColor: props.theme.background.middle,
-  };
-})`
+const LogoutButtonStyled = styled(Button)`
+  background-color: ${(props) => props.theme.background.middle};
   position: absolute;
   top: 2.5%;
   left: 2%;
   border: none;
+  width: 3.5%;
+  height: 4.5%;
 `;
 
 const LogoutButton = ({ to }: Props) => {
   return (
-    <LogoutButtonStyled to={to}>
+    <LogoutButtonStyled width="3.5%" height="4.5%" to={to}>
       <LogoutLogo />
     </LogoutButtonStyled>
   );

--- a/frontend/src/components/modules/UserInfoModal/UserInfoModal.tsx
+++ b/frontend/src/components/modules/UserInfoModal/UserInfoModal.tsx
@@ -54,10 +54,10 @@ const UserInfoModal = ({ onClose, width, height }: Props) => {
         <GridList
           width="100%"
           height="100%"
-          titleList={["게임종류", "승리", "패배", "승률", "랭킹"]}
+          titleList={["게임종류", "승리", "패배", "승률"]}
           contentList={[
-            ["레더게임", "10", "5", "66.7%", "1"],
-            ["일반게임", "10", "5", "66.7%", "2"],
+            ["레더게임", "10", "5", "66.7%"],
+            ["일반게임", "10", "5", "66.7%"],
           ]}
         />
       </Stat>
@@ -70,10 +70,13 @@ const UserInfoModal = ({ onClose, width, height }: Props) => {
         </ContentListWrapper>
       </State>
       <ButtonGroup width="100%" height="10%" backgroundColor="secondary">
-        <Button width="35%" height="75%" boxShadow fontSize="2rem">
+        <Button width="30%" height="75%" boxShadow fontSize="2rem">
           친구추가
         </Button>
-        <Button width="35%" height="75%" boxShadow fontSize="2rem">
+        <Button width="30%" height="75%" boxShadow fontSize="2rem" to="/stat/1">
+          최근전적
+        </Button>
+        <Button width="30%" height="75%" boxShadow fontSize="2rem">
           관전하기
         </Button>
       </ButtonGroup>


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>중대한 사항이라면 상세히 적어주세요.
수정 결과입니다.
이전 결과는 #37 에 있습니다.
<img width="517" alt="image" src="https://user-images.githubusercontent.com/74703501/216285752-f051ab1c-3e51-4e43-8d7c-a938333e38a9.png">
<img width="906" alt="image" src="https://user-images.githubusercontent.com/74703501/216285774-c23da854-37ee-4e54-baea-1427bf85612f.png">

close #37 