### PR TITLE
[COMMON] nginx가 websocket 연결을 유지하도록 수정

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -76,4 +76,12 @@ server {
     proxy_pass http://host.docker.internal:3000;
     proxy_set_header Host $host;
   }
+
+   location ^~ /socket {
+    proxy_pass http://host.docker.internal:3000;
+    proxy_set_header Host $host;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+  }
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [x] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>중대한 사항이라면 상세히 적어주세요.

nginx가 websocket 연결을 유지하도록 `nginx.conf`를 수정했습니다.
클라이언트가 특정 namespace에 연결 요청을 보낼 때는 `localhost/socket/chat` 과 같은 형태로 요청해야 합니다.

<img width="743" alt="스크린샷 2023-02-11 오후 4 51 15" src="https://user-images.githubusercontent.com/83565255/218247082-e0543322-11fd-4854-8401-294bb91592a9.png">

또한 웹소켓 게이트웨이에서 따로 포트를 파지 않고 namespace로 관리하는게 의미를 구분하는데 유용할 것 같아
위와 같이 port 대신 namespace필드에 `socket/chat` 형태로 수정 부탁드립니다..!

