### PR TITLE
[BE] stat 관련 API 구현

### DIFF
--- a/backend/src/dto/match.history.dto.ts
+++ b/backend/src/dto/match.history.dto.ts
@@ -11,7 +11,7 @@ export class MatchHistoryDto {
   opponent: UserDto; // 대전 상대 유저 정보
   myScore: number; // 내 점수
   opponentScore: number; // 상대 점수
-  beginDate: string; // 대전 시작 시간
+  beginDate: Date; // 대전 시작 시간
   matchTime: number; // 대전 시간(ms)
   matchType: MatchType; // 대전 유형
 }

--- a/backend/src/dto/response/rank.list.response.dto.ts
+++ b/backend/src/dto/response/rank.list.response.dto.ts
@@ -7,5 +7,4 @@ import { RankDto } from '../rank.dto';
  */
 export class RankListResponseDto {
   rankList: RankDto[]; // 순위 정보 리스트
-  isLast: boolean; // 마지막 페이지인지 여부
 }

--- a/backend/src/entity/match.history.entity.ts
+++ b/backend/src/entity/match.history.entity.ts
@@ -11,10 +11,10 @@ import User from './user.entity';
 @Entity('match_history')
 export default class MatchHistory {
   @PrimaryGeneratedColumn({
-    name: 'history_id',
+    name: 'match_id',
     type: 'int',
   })
-  historyId: number;
+  matchId: number;
 
   @Column({
     name: 'red_user_id',

--- a/backend/src/enum/ranking.filter.enum.ts
+++ b/backend/src/enum/ranking.filter.enum.ts
@@ -1,0 +1,6 @@
+export enum RankingFilter {
+  LADDER_SCORE = 'ladderScore',
+  WIN_COUNT = 'winCount',
+  LOSE_COUNT = 'loseCount',
+  WIN_RATE = 'winRate',
+}

--- a/backend/src/enum/sort.direction.enum.ts
+++ b/backend/src/enum/sort.direction.enum.ts
@@ -1,0 +1,4 @@
+export enum SortDirection {
+  ASC = 'ASC',
+  DESC = 'DESC',
+}

--- a/backend/src/stat/repository/stat.repository.interface.ts
+++ b/backend/src/stat/repository/stat.repository.interface.ts
@@ -1,0 +1,9 @@
+import { MatchHistoryDto } from 'src/dto/match.history.dto';
+
+export interface IStatRepository {
+  /**
+   * 유저의 최근 전적을 가져옵니다.
+   * @param userId
+   */
+  getRecentRecord(userId: number): Promise<MatchHistoryDto[]>;
+}

--- a/backend/src/stat/repository/stat.repository.interface.ts
+++ b/backend/src/stat/repository/stat.repository.interface.ts
@@ -1,6 +1,13 @@
 import { MatchHistoryDto } from 'src/dto/match.history.dto';
+import { RankDto } from 'src/dto/rank.dto';
+import { RankingFilter } from 'src/enum/ranking.filter.enum';
 
 export interface IStatRepository {
+  /**
+   * 전체 유저의 랭킹을 가져옵니다.
+   */
+  getRanking(filter: RankingFilter, order: string): Promise<RankDto[]>;
+
   /**
    * 유저의 최근 전적을 가져옵니다.
    * @param userId

--- a/backend/src/stat/repository/stat.repository.interface.ts
+++ b/backend/src/stat/repository/stat.repository.interface.ts
@@ -1,12 +1,13 @@
 import { MatchHistoryDto } from 'src/dto/match.history.dto';
 import { RankDto } from 'src/dto/rank.dto';
 import { RankingFilter } from 'src/enum/ranking.filter.enum';
+import { SortDirection } from 'src/enum/sort.direction.enum';
 
 export interface IStatRepository {
   /**
    * 전체 유저의 랭킹을 가져옵니다.
    */
-  getRanking(filter: RankingFilter, order: string): Promise<RankDto[]>;
+  getRanking(filter: RankingFilter, order: SortDirection): Promise<RankDto[]>;
 
   /**
    * 유저의 최근 전적을 가져옵니다.

--- a/backend/src/stat/repository/stat.repository.ts
+++ b/backend/src/stat/repository/stat.repository.ts
@@ -1,0 +1,90 @@
+import { Logger } from '@nestjs/common';
+import { IStatRepository } from './stat.repository.interface';
+import { InjectRepository } from '@nestjs/typeorm';
+import MatchHistory from 'src/entity/match.history.entity';
+import { Repository } from 'typeorm';
+import { MatchHistoryDto } from 'src/dto/match.history.dto';
+import { MatchResult } from 'src/enum/match.result.enum';
+
+export class StatRepository implements IStatRepository {
+  private logger = new Logger(StatRepository.name);
+  constructor(
+    @InjectRepository(MatchHistory)
+    private readonly matchHistoryRepository: Repository<MatchHistory>,
+  ) {}
+  async getRecentRecord(userId: number): Promise<MatchHistoryDto[]> {
+    this.logger.log(`Called ${this.getRecentRecord.name}`);
+    // userId로 최근 10개의 매치 기록을 가져온다.
+    const results = await this.matchHistoryRepository.find({
+      relations: {
+        redUser: true,
+        blueUser: true,
+      },
+      // userId가 redUser or blueUser인 것을 찾는다.
+      where: [
+        {
+          redUser: {
+            userId,
+          },
+        },
+        {
+          blueUser: {
+            userId,
+          },
+        },
+      ],
+      order: {
+        beginDate: 'DESC',
+      },
+      select: {
+        matchId: true,
+        redScore: true,
+        blueScore: true,
+        beginDate: true,
+        endDate: true,
+        redUser: {
+          userId: true,
+          nickname: true,
+          avatarUrl: true,
+        },
+        blueUser: {
+          userId: true,
+          nickname: true,
+          avatarUrl: true,
+        },
+        matchType: true,
+      },
+    });
+
+    // 매치 기록이 없으면 null을 반환한다.
+    if (results.length === 0) {
+      return null;
+    }
+    // results를 MatchHistoryDto[]로 변환한다.
+    const matchHistories: MatchHistoryDto[] = results.map((result) => {
+      const matchHistory = new MatchHistoryDto();
+      matchHistory.matchId = result.matchId;
+
+      // userId가 redUser인지 blueUser인지 확인한다.
+      if (result.redUser.userId === userId) {
+        matchHistory.myScore = result.redScore;
+        matchHistory.opponent = result.blueUser;
+        matchHistory.opponentScore = result.blueScore;
+      } else {
+        matchHistory.myScore = result.blueScore;
+        matchHistory.opponent = result.redUser;
+        matchHistory.opponentScore = result.redScore;
+      }
+      matchHistory.matchResult =
+        matchHistory.myScore > matchHistory.opponentScore
+          ? MatchResult.WIN
+          : MatchResult.LOSE;
+      matchHistory.beginDate = result.beginDate;
+      matchHistory.matchTime =
+        result.endDate.getTime() - result.beginDate.getTime();
+      matchHistory.matchType = result.matchType;
+      return matchHistory;
+    });
+    return matchHistories;
+  }
+}

--- a/backend/src/stat/repository/stat.repository.ts
+++ b/backend/src/stat/repository/stat.repository.ts
@@ -82,6 +82,7 @@ export class StatRepository implements IStatRepository {
       order: {
         beginDate: 'DESC',
       },
+      take: 10,
       select: {
         matchId: true,
         redScore: true,

--- a/backend/src/stat/repository/stat.repository.ts
+++ b/backend/src/stat/repository/stat.repository.ts
@@ -8,6 +8,7 @@ import { MatchResult } from 'src/enum/match.result.enum';
 import { RankDto } from 'src/dto/rank.dto';
 import LadderStat from 'src/entity/ladder.stat.entity';
 import { RankingFilter } from 'src/enum/ranking.filter.enum';
+import { SortDirection } from 'src/enum/sort.direction.enum';
 
 export class StatRepository implements IStatRepository {
   private logger = new Logger(StatRepository.name);
@@ -19,7 +20,10 @@ export class StatRepository implements IStatRepository {
     private readonly ladderStatRepository: Repository<LadderStat>,
   ) {}
 
-  async getRanking(filter: RankingFilter, order: string): Promise<RankDto[]> {
+  async getRanking(
+    filter: RankingFilter,
+    order: SortDirection,
+  ): Promise<RankDto[]> {
     this.logger.log(`Called ${this.getRanking.name}`);
     // 전체 유저의 랭킹을 가져온다.
     const results = await this.ladderStatRepository

--- a/backend/src/stat/stat.controller.ts
+++ b/backend/src/stat/stat.controller.ts
@@ -1,4 +1,12 @@
-import { Controller, Get, Logger, Param, ParseIntPipe } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Logger,
+  Param,
+  ParseEnumPipe,
+  ParseIntPipe,
+  Query,
+} from '@nestjs/common';
 import { UserRecentMatchHistoryResponseDto } from '../dto/response/user.recent.match.history.response.dto';
 import { MatchResult } from '../enum/match.result.enum';
 import { MatchType } from '../enum/match.type.enum';
@@ -7,6 +15,7 @@ import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { User } from '../decorator/user.decorator';
 import { UserDto } from '../dto/user.dto';
 import { StatService } from './stat.service';
+import { RankingFilter } from 'src/enum/ranking.filter.enum';
 
 @ApiTags('Stat')
 @Controller('api/stat')
@@ -20,9 +29,12 @@ export class StatController {
     description: '전체 유저의 랭킹을 조회합니다.',
   })
   @Get('ranking')
-  async getRanking(@User() user: UserDto) {
+  async getRanking(
+    @Query('filter', new ParseEnumPipe(RankingFilter)) filter: RankingFilter,
+    @Query('order') order: string,
+  ): Promise<RankListResponseDto> {
     this.logger.log(`Called ${this.getRanking.name}`);
-    return;
+    return await this.statService.getRanking(filter, order);
   }
 
   @ApiOperation({

--- a/backend/src/stat/stat.controller.ts
+++ b/backend/src/stat/stat.controller.ts
@@ -12,6 +12,7 @@ import { RankListResponseDto } from '../dto/response/rank.list.response.dto';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { StatService } from './stat.service';
 import { RankingFilter } from 'src/enum/ranking.filter.enum';
+import { SortDirection } from 'src/enum/sort.direction.enum';
 
 @ApiTags('Stat')
 @Controller('api/stat')
@@ -27,7 +28,7 @@ export class StatController {
   @Get('ranking')
   async getRanking(
     @Query('filter', new ParseEnumPipe(RankingFilter)) filter: RankingFilter,
-    @Query('order') order: string,
+    @Query('order', new ParseEnumPipe(SortDirection)) order: SortDirection,
   ): Promise<RankListResponseDto> {
     this.logger.log(`Called ${this.getRanking.name}`);
     return await this.statService.getRanking(filter, order);

--- a/backend/src/stat/stat.controller.ts
+++ b/backend/src/stat/stat.controller.ts
@@ -8,12 +8,8 @@ import {
   Query,
 } from '@nestjs/common';
 import { UserRecentMatchHistoryResponseDto } from '../dto/response/user.recent.match.history.response.dto';
-import { MatchResult } from '../enum/match.result.enum';
-import { MatchType } from '../enum/match.type.enum';
 import { RankListResponseDto } from '../dto/response/rank.list.response.dto';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
-import { User } from '../decorator/user.decorator';
-import { UserDto } from '../dto/user.dto';
 import { StatService } from './stat.service';
 import { RankingFilter } from 'src/enum/ranking.filter.enum';
 

--- a/backend/src/stat/stat.controller.ts
+++ b/backend/src/stat/stat.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Logger, Param } from '@nestjs/common';
+import { Controller, Get, Logger, Param, ParseIntPipe } from '@nestjs/common';
 import { UserRecentMatchHistoryResponseDto } from '../dto/response/user.recent.match.history.response.dto';
 import { MatchResult } from '../enum/match.result.enum';
 import { MatchType } from '../enum/match.type.enum';
@@ -6,67 +6,14 @@ import { RankListResponseDto } from '../dto/response/rank.list.response.dto';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { User } from '../decorator/user.decorator';
 import { UserDto } from '../dto/user.dto';
-
-const gameRet: UserRecentMatchHistoryResponseDto = {
-  userInfo: {
-    userId: 1,
-    nickname: 'sichoi',
-    avatarUrl: 'https://example.com',
-  },
-  matchHistories: [],
-};
-const formatDate = () => {
-  const date = new Date();
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  const hour = String(date.getHours()).padStart(2, '0');
-  const minute = String(date.getMinutes()).padStart(2, '0');
-  const second = String(date.getSeconds()).padStart(2, '0');
-
-  return `${year}-${month}-${day} ${hour}:${minute}:${second}`;
-};
-
-for (let i = 0; i < 11; ++i) {
-  gameRet.matchHistories.push({
-    matchId: i,
-    matchResult: i % 2 == 0 ? MatchResult.WIN : MatchResult.LOSE,
-    opponent: {
-      userId: 2,
-      nickname: 'youngpar',
-      avatarUrl: 'https://example.com',
-    },
-    myScore: 11,
-    opponentScore: 8,
-    beginDate: formatDate(),
-    matchTime: 612,
-    matchType: i % 2 == 0 ? MatchType.LADDER : MatchType.NORMAL,
-  });
-}
-
-const rankRet: RankListResponseDto = {
-  rankList: [],
-  isLast: false,
-};
-for (let i = 0; i < 38; ++i) {
-  rankRet.rankList.push({
-    ranking: i + 1,
-    userInfo: {
-      userId: i,
-      nickname: `sichoi${i}`,
-      avatarUrl: 'https://example.com',
-    },
-    ladderScore: 1200 - i * 10,
-    winCount: 50 - i,
-    loseCount: i,
-    winRate: Math.round(((50 - i) / 50) * 100),
-  });
-}
+import { StatService } from './stat.service';
 
 @ApiTags('Stat')
 @Controller('api/stat')
 export class StatController {
   private logger = new Logger(StatController.name);
+
+  constructor(private readonly statService: StatService) {}
 
   @ApiOperation({
     summary: '랭킹',
@@ -75,16 +22,18 @@ export class StatController {
   @Get('ranking')
   async getRanking(@User() user: UserDto) {
     this.logger.log(`Called ${this.getRanking.name}`);
-    return rankRet;
+    return;
   }
 
   @ApiOperation({
     summary: '최근 전적',
-    description: '특정 유저의 최근 전적 조회',
+    description: '특정 유저의 최근 전적을 조회합니다.',
   })
   @Get('recent-records/:user_id')
-  async getGameRecord(@Param('user_id') userId: number) {
-    this.logger.log(`Called ${this.getGameRecord.name}`);
-    return gameRet;
+  async getRecentRecord(
+    @Param('user_id', ParseIntPipe) userId: number,
+  ): Promise<UserRecentMatchHistoryResponseDto> {
+    this.logger.log(`Called ${this.getRecentRecord.name}`);
+    return await this.statService.getRecentRecord(userId);
   }
 }

--- a/backend/src/stat/stat.module.ts
+++ b/backend/src/stat/stat.module.ts
@@ -1,7 +1,19 @@
 import { Module } from '@nestjs/common';
 import { StatController } from './stat.controller';
+import { StatService } from './stat.service';
+import { StatRepository } from './repository/stat.repository';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import MatchHistory from 'src/entity/match.history.entity';
+import { UserModule } from 'src/user/user.module';
+
+const repo = {
+  provide: 'IStatRepository',
+  useClass: StatRepository,
+};
 
 @Module({
+  imports: [TypeOrmModule.forFeature([MatchHistory]), UserModule],
   controllers: [StatController],
+  providers: [StatService, repo],
 })
 export class StatModule {}

--- a/backend/src/stat/stat.module.ts
+++ b/backend/src/stat/stat.module.ts
@@ -5,6 +5,7 @@ import { StatRepository } from './repository/stat.repository';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import MatchHistory from 'src/entity/match.history.entity';
 import { UserModule } from 'src/user/user.module';
+import LadderStat from 'src/entity/ladder.stat.entity';
 
 const repo = {
   provide: 'IStatRepository',
@@ -12,7 +13,7 @@ const repo = {
 };
 
 @Module({
-  imports: [TypeOrmModule.forFeature([MatchHistory]), UserModule],
+  imports: [TypeOrmModule.forFeature([MatchHistory, LadderStat]), UserModule],
   controllers: [StatController],
   providers: [StatService, repo],
 })

--- a/backend/src/stat/stat.service.ts
+++ b/backend/src/stat/stat.service.ts
@@ -4,6 +4,7 @@ import { UserRecentMatchHistoryResponseDto } from 'src/dto/response/user.recent.
 import { UserService } from 'src/user/user.service';
 import { RankListResponseDto } from 'src/dto/response/rank.list.response.dto';
 import { RankingFilter } from 'src/enum/ranking.filter.enum';
+import { SortDirection } from 'src/enum/sort.direction.enum';
 
 @Injectable()
 export class StatService {
@@ -17,7 +18,7 @@ export class StatService {
 
   async getRanking(
     filter: RankingFilter,
-    order: string,
+    order: SortDirection,
   ): Promise<RankListResponseDto> {
     this.logger.log(`Called ${this.getRanking.name}`);
     const rankList = await this.statRepository.getRanking(filter, order);

--- a/backend/src/stat/stat.service.ts
+++ b/backend/src/stat/stat.service.ts
@@ -1,0 +1,30 @@
+import { Inject, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { IStatRepository } from './repository/stat.repository.interface';
+import { UserRecentMatchHistoryResponseDto } from 'src/dto/response/user.recent.match.history.response.dto';
+import { UserService } from 'src/user/user.service';
+
+@Injectable()
+export class StatService {
+  private logger = new Logger(StatService.name);
+
+  constructor(
+    @Inject('IStatRepository')
+    private readonly statRepository: IStatRepository,
+    private readonly userService: UserService,
+  ) {}
+
+  async getRecentRecord(
+    userId: number,
+  ): Promise<UserRecentMatchHistoryResponseDto> {
+    this.logger.log(`Called ${this.getRecentRecord.name}`);
+    const userInfo = await this.userService.getUserInfo(userId);
+    if (!userInfo) {
+      throw new NotFoundException('존재하지 않는 유저입니다.');
+    }
+    const matchHistories = await this.statRepository.getRecentRecord(userId);
+    return {
+      userInfo,
+      matchHistories,
+    } as UserRecentMatchHistoryResponseDto;
+  }
+}

--- a/backend/src/stat/stat.service.ts
+++ b/backend/src/stat/stat.service.ts
@@ -2,6 +2,8 @@ import { Inject, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { IStatRepository } from './repository/stat.repository.interface';
 import { UserRecentMatchHistoryResponseDto } from 'src/dto/response/user.recent.match.history.response.dto';
 import { UserService } from 'src/user/user.service';
+import { RankListResponseDto } from 'src/dto/response/rank.list.response.dto';
+import { RankingFilter } from 'src/enum/ranking.filter.enum';
 
 @Injectable()
 export class StatService {
@@ -12,6 +14,17 @@ export class StatService {
     private readonly statRepository: IStatRepository,
     private readonly userService: UserService,
   ) {}
+
+  async getRanking(
+    filter: RankingFilter,
+    order: string,
+  ): Promise<RankListResponseDto> {
+    this.logger.log(`Called ${this.getRanking.name}`);
+    const rankList = await this.statRepository.getRanking(filter, order);
+    return {
+      rankList: rankList,
+    } as RankListResponseDto;
+  }
 
   async getRecentRecord(
     userId: number,

--- a/backend/src/user/repository/user.repository.interface.ts
+++ b/backend/src/user/repository/user.repository.interface.ts
@@ -1,0 +1,9 @@
+import { UserDto } from 'src/dto/user.dto';
+
+export interface IUserRepository {
+  /**
+   * userId로 유저 정보를 가져옵니다.
+   * @param userId
+   */
+  getUserInfo(userId: number): Promise<UserDto>;
+}

--- a/backend/src/user/repository/user.repository.ts
+++ b/backend/src/user/repository/user.repository.ts
@@ -1,0 +1,30 @@
+import { Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { UserDto } from 'src/dto/user.dto';
+import User from 'src/entity/user.entity';
+import { Repository } from 'typeorm';
+import { IUserRepository } from './user.repository.interface';
+
+export class UserRepository implements IUserRepository {
+  private logger = new Logger(UserRepository.name);
+
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+  ) {}
+
+  async getUserInfo(userId: number): Promise<UserDto> {
+    this.logger.log(`Called ${this.getUserInfo.name}`);
+    const user = await this.userRepository.findOne({
+      where: { userId },
+    });
+    if (!user) {
+      return null;
+    }
+    return {
+      userId: user.userId,
+      nickname: user.nickname,
+      avatarUrl: user.avatarUrl,
+    } as UserDto;
+  }
+}

--- a/backend/src/user/user.module.ts
+++ b/backend/src/user/user.module.ts
@@ -2,9 +2,20 @@ import { Module } from '@nestjs/common';
 import { UserController } from './user.controller';
 import { ChatModule } from '../chat/chat.module';
 import { GameModule } from '../game/game.module';
+import { UserRepository } from './repository/user.repository';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import User from 'src/entity/user.entity';
+import { UserService } from './user.service';
+
+const repo = {
+  provide: 'IUserRepository',
+  useClass: UserRepository,
+};
 
 @Module({
-  imports: [ChatModule, GameModule],
+  imports: [TypeOrmModule.forFeature([User]), ChatModule, GameModule],
   controllers: [UserController],
+  providers: [UserService, repo],
+  exports: [UserService],
 })
 export class UserModule {}

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -1,0 +1,22 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { UserDto } from 'src/dto/user.dto';
+import { IUserRepository } from './repository/user.repository.interface';
+
+@Injectable()
+export class UserService {
+  private logger = new Logger(UserService.name);
+
+  constructor(
+    @Inject('IUserRepository')
+    private readonly userRepository: IUserRepository,
+  ) {}
+
+  /**
+   * userId로 유저 정보를 가져옵니다.
+   * @param userId
+   */
+  async getUserInfo(userId: number): Promise<UserDto> {
+    this.logger.log(`Called ${this.getUserInfo.name}`);
+    return await this.userRepository.getUserInfo(userId);
+  }
+}

--- a/postgres/pong_arcade.sql
+++ b/postgres/pong_arcade.sql
@@ -16,6 +16,22 @@ SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
 
+--
+-- Name: public; Type: SCHEMA; Schema: -; Owner: pg_database_owner
+--
+
+CREATE SCHEMA public;
+
+
+ALTER SCHEMA public OWNER TO pg_database_owner;
+
+--
+-- Name: SCHEMA public; Type: COMMENT; Schema: -; Owner: pg_database_owner
+--
+
+COMMENT ON SCHEMA public IS 'standard public schema';
+
+
 SET default_tablespace = '';
 
 SET default_table_access_method = heap;
@@ -74,13 +90,13 @@ COMMENT ON COLUMN public.ladder_stat.ladder_score IS '래더 점수';
 --
 
 CREATE TABLE public.match_history (
-    history_id integer NOT NULL,
+    match_id integer NOT NULL,
     red_user_id integer DEFAULT 0 NOT NULL,
     blue_user_id integer DEFAULT 0 NOT NULL,
     red_score integer NOT NULL,
     blue_score integer NOT NULL,
-    begin_time timestamp without time zone NOT NULL,
-    end_time timestamp without time zone NOT NULL,
+    begin_date timestamp without time zone NOT NULL,
+    end_date timestamp without time zone NOT NULL,
     match_type character varying(16) NOT NULL
 );
 
@@ -123,18 +139,18 @@ COMMENT ON COLUMN public.match_history.blue_score IS '블루팀 점수';
 
 
 --
--- Name: COLUMN match_history.begin_time; Type: COMMENT; Schema: public; Owner: arcade
+-- Name: COLUMN match_history.begin_date; Type: COMMENT; Schema: public; Owner: arcade
 --
 
-COMMENT ON COLUMN public.match_history.begin_time IS '게임 시작 시간
+COMMENT ON COLUMN public.match_history.begin_date IS '게임 시작 시간
 ';
 
 
 --
--- Name: COLUMN match_history.end_time; Type: COMMENT; Schema: public; Owner: arcade
+-- Name: COLUMN match_history.end_date; Type: COMMENT; Schema: public; Owner: arcade
 --
 
-COMMENT ON COLUMN public.match_history.end_time IS '게임 종료 시간';
+COMMENT ON COLUMN public.match_history.end_date IS '게임 종료 시간';
 
 
 --
@@ -163,7 +179,7 @@ ALTER TABLE public.match_history_history_id_seq OWNER TO arcade;
 -- Name: match_history_history_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: arcade
 --
 
-ALTER SEQUENCE public.match_history_history_id_seq OWNED BY public.match_history.history_id;
+ALTER SEQUENCE public.match_history_history_id_seq OWNED BY public.match_history.match_id;
 
 
 --
@@ -291,13 +307,6 @@ COMMENT ON COLUMN public."user".email IS '유저의 이메일';
 
 
 --
--- Name: match_history history_id; Type: DEFAULT; Schema: public; Owner: arcade
---
-
-ALTER TABLE ONLY public.match_history ALTER COLUMN history_id SET DEFAULT nextval('public.match_history_history_id_seq'::regclass);
-
-
---
 -- Data for Name: ladder_stat; Type: TABLE DATA; Schema: public; Owner: arcade
 --
 
@@ -309,7 +318,7 @@ COPY public.ladder_stat (user_id, win_count, lose_count, ladder_score) FROM stdi
 -- Data for Name: match_history; Type: TABLE DATA; Schema: public; Owner: arcade
 --
 
-COPY public.match_history (history_id, red_user_id, blue_user_id, red_score, blue_score, begin_time, end_time, match_type) FROM stdin;
+COPY public.match_history (match_id, red_user_id, blue_user_id, red_score, blue_score, begin_date, end_date, match_type) FROM stdin;
 \.
 
 
@@ -335,6 +344,7 @@ COPY public.relation (user_id, other_user_id, relation_type) FROM stdin;
 
 COPY public."user" (user_id, nickname, avatar_url, email) FROM stdin;
 85330	sichoi	https://cdn.intra.42.fr/users/6b58f90b32b08da5c68579c72f884599/sichoi.jpg	sichoi@student.42seoul.kr
+1	test	\N	\N
 \.
 
 
@@ -354,11 +364,19 @@ ALTER TABLE ONLY public.ladder_stat
 
 
 --
+-- Name: match_history match_history_match_id_key; Type: CONSTRAINT; Schema: public; Owner: arcade
+--
+
+ALTER TABLE ONLY public.match_history
+    ADD CONSTRAINT match_history_match_id_key UNIQUE (match_id);
+
+
+--
 -- Name: match_history match_history_pk; Type: CONSTRAINT; Schema: public; Owner: arcade
 --
 
 ALTER TABLE ONLY public.match_history
-    ADD CONSTRAINT match_history_pk PRIMARY KEY (history_id);
+    ADD CONSTRAINT match_history_pk PRIMARY KEY (match_id);
 
 
 --


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>중대한 사항이라면 상세히 적어주세요.

stat 모듈 API를 구현완료했습니다.
1. /api/stat/recent-records/:user-id
2. /api/stat/ranking

1번의 경우 beginDate를 기준으로 최근 10개만 가져오도록 했습니다.
2번의 경우 query string으로 filter와 order를 입력해야 합니다.

filter는 validation pipe를 통해, 아래 enum에 해당하는 값들만 통과시키고, 그 외의 문자는 400 Bad Request를 응답합니다.
```
export enum RankingFilter {
  LADDER_SCORE = 'ladderScore',
  WIN_COUNT = 'winCount',
  LOSE_COUNT = 'loseCount',
  WIN_RATE = 'winRate',
}
```

order도 마찬가지로 ASC | DESC만 넣을 수 있도록 조치했습니다. 그 외의 문자는 400 Bad Request를 응답합니다.
```
export enum SortDirection {
  ASC = 'ASC',
  DESC = 'DESC',
}

```