### PR TITLE
[BE] DTO에 swagger 명세 추가

### DIFF
--- a/backend/src/dto/chatroom.list.dto.ts
+++ b/backend/src/dto/chatroom.list.dto.ts
@@ -1,12 +1,38 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { ChatRoomMode } from 'src/enum/chatroom.mode.enum';
 
 /**
  * 채팅방 목록을 반환하는 dto입니다.
  */
 export class ChatRoomListDto {
-  roomId: number; // 채팅방 ID
-  title: string; // 채팅방 제목
-  mode: ChatRoomMode; // 채팅방 모드
-  maxUserCount: number; // 최대 유저 수
-  currentCount: number; // 현재 유저 수
+  @ApiProperty({
+    description: '채팅방 ID',
+    example: 1,
+  })
+  roomId: number;
+
+  @ApiProperty({
+    description: '채팅방 제목',
+    example: '채팅방 제목입니다.',
+  })
+  title: string;
+
+  @ApiProperty({
+    description: '채팅방 모드 (비밀번호/초대전용/공개)',
+    example: ChatRoomMode.PROTECTED,
+    enum: ChatRoomMode,
+  })
+  mode: ChatRoomMode;
+
+  @ApiProperty({
+    description: '최대 유저 수',
+    example: 10,
+  })
+  maxUserCount: number;
+
+  @ApiProperty({
+    description: '현재 유저 수',
+    example: 5,
+  })
+  currentCount: number;
 }

--- a/backend/src/dto/gameroom.list.dto.ts
+++ b/backend/src/dto/gameroom.list.dto.ts
@@ -1,14 +1,55 @@
 import { GameRoomStatus } from 'src/enum/gameroom.status.enum';
 import { UserDto } from './user.dto';
+import { ApiProperty } from '@nestjs/swagger';
 
 /**
  * 게임방 목록을 반환하는 dto입니다.
  */
 export class GameRoomListDto {
-  roomId: number; // 게임방 ID
-  redUser: UserDto; // 빨간 팀 유저
-  blueUser: UserDto; // 파란 팀 유저
-  maxSpectatorCount: number; // 최대 관전자 수
-  curSpectatorCount: number; // 현재 관전자 수
-  roomStatus: GameRoomStatus; // 게임방 상태
+  @ApiProperty({
+    description: '게임방 ID',
+    example: 1,
+  })
+  roomId: number;
+
+  @ApiProperty({
+    description: '빨간 팀 유저',
+    example: {
+      userId: 1,
+      nickname: 'redUser',
+      avatarUrl: 'http://example.com',
+    } as UserDto,
+    type: UserDto,
+  })
+  redUser: UserDto;
+
+  @ApiProperty({
+    description: '파란 팀 유저',
+    example: {
+      userId: 2,
+      nickname: 'blueUser',
+      avatarUrl: 'http://example.com',
+    } as UserDto,
+    type: UserDto,
+  })
+  blueUser: UserDto;
+
+  @ApiProperty({
+    description: '최대 관전자 수',
+    example: 10,
+  })
+  maxSpectatorCount: number;
+
+  @ApiProperty({
+    description: '현재 관전자 수',
+    example: 5,
+  })
+  curSpectatorCount: number;
+
+  @ApiProperty({
+    description: '게임방 상태(게임중/대기중)',
+    example: GameRoomStatus.ON_GAME,
+    enum: GameRoomStatus,
+  })
+  roomStatus: GameRoomStatus;
 }

--- a/backend/src/dto/match.history.dto.ts
+++ b/backend/src/dto/match.history.dto.ts
@@ -1,17 +1,65 @@
 import { MatchResult } from 'src/enum/match.result.enum';
 import { UserDto } from './user.dto';
 import { MatchType } from 'src/enum/match.type.enum';
+import { ApiProperty } from '@nestjs/swagger';
 
 /**
  * 대전 기록을 저장하는 dto입니다.
  */
 export class MatchHistoryDto {
-  matchId: number; // 대전의 고유 아이디
-  matchResult: MatchResult; // 대전의 결과
-  opponent: UserDto; // 대전 상대 유저 정보
-  myScore: number; // 내 점수
-  opponentScore: number; // 상대 점수
-  beginDate: Date; // 대전 시작 시간
-  matchTime: number; // 대전 시간(ms)
-  matchType: MatchType; // 대전 유형
+  @ApiProperty({
+    description: '대전의 고유 아이디',
+    example: 1,
+  })
+  matchId: number;
+
+  @ApiProperty({
+    description: '대전의 결과',
+    example: MatchResult.WIN,
+    enum: MatchResult,
+  })
+  matchResult: MatchResult;
+
+  @ApiProperty({
+    description: '대전 상대 유저 정보',
+    example: {
+      userId: 2,
+      nickname: 'opponentUser',
+      avatarUrl: 'http://example.com',
+    } as UserDto,
+    type: UserDto,
+  })
+  opponent: UserDto;
+
+  @ApiProperty({
+    description: '내 점수',
+    example: 10,
+  })
+  myScore: number;
+
+  @ApiProperty({
+    description: '상대 점수',
+    example: 5,
+  })
+  opponentScore: number;
+
+  @ApiProperty({
+    description: '대전 시작 시간',
+    example: '2023-02-15T00:00:00.000Z',
+    type: Date,
+  })
+  beginDate: Date;
+
+  @ApiProperty({
+    description: '대전 시간(ms)',
+    example: 1000,
+  })
+  matchTime: number;
+
+  @ApiProperty({
+    description: '대전 유형(래더/일반)',
+    example: MatchType.LADDER,
+    enum: MatchType,
+  })
+  matchType: MatchType;
 }

--- a/backend/src/dto/rank.dto.ts
+++ b/backend/src/dto/rank.dto.ts
@@ -1,13 +1,48 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { UserDto } from './user.dto';
 
 /**
  * 순위 정보를 저장하는 dto입니다.
  */
 export class RankDto {
-  ranking: number; // 순위
-  userInfo: UserDto; // 유저 정보
-  ladderScore: number; // 점수
-  winCount: number; // 승리 횟수
-  loseCount: number; // 패배 횟수
-  winRate: number; // 승률
+  @ApiProperty({
+    description: '순위',
+    example: 1,
+  })
+  ranking: number;
+
+  @ApiProperty({
+    description: '유저 정보',
+    example: {
+      userId: 1,
+      nickname: 'user1',
+      avatarUrl: 'http://example.com',
+    } as UserDto,
+    type: UserDto,
+  })
+  userInfo: UserDto;
+
+  @ApiProperty({
+    description: '래더 점수',
+    example: 1000,
+  })
+  ladderScore: number;
+
+  @ApiProperty({
+    description: '승리 횟수',
+    example: 9,
+  })
+  winCount: number;
+
+  @ApiProperty({
+    description: '패배 횟수',
+    example: 1,
+  })
+  loseCount: number;
+
+  @ApiProperty({
+    description: '승률',
+    example: 90,
+  })
+  winRate: number;
 }

--- a/backend/src/dto/request/chatroom.create.request.dto.ts
+++ b/backend/src/dto/request/chatroom.create.request.dto.ts
@@ -1,3 +1,4 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { ChatRoomMode } from 'src/enum/chatroom.mode.enum';
 
 /**
@@ -8,8 +9,29 @@ import { ChatRoomMode } from 'src/enum/chatroom.mode.enum';
  * maxUserCount는 채팅방의 최대 인원 수를 저장합니다.
  */
 export class ChatroomCreateRequestDto {
+  @ApiProperty({
+    description: '채팅방 모드 (비밀번호/초대전용/공개)',
+    example: ChatRoomMode.PROTECTED,
+    enum: ChatRoomMode,
+  })
   mode: ChatRoomMode;
+
+  @ApiProperty({
+    description: '채팅방 제목',
+    example: '채팅방 제목입니다.',
+  })
   title: string;
+
+  @ApiProperty({
+    description: '채팅방 비밀번호(optional)',
+    example: '1234',
+    required: false,
+  })
   password?: string;
+
+  @ApiProperty({
+    description: '채팅방 최대 인원 수',
+    example: 10,
+  })
   maxUserCount: number;
 }

--- a/backend/src/dto/request/gameroom.create.request.dto.ts
+++ b/backend/src/dto/request/gameroom.create.request.dto.ts
@@ -1,3 +1,4 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { GameRoomMode } from 'src/enum/gameroom.mode.enum';
 import { MatchType } from 'src/enum/match.type.enum';
 
@@ -10,9 +11,36 @@ import { MatchType } from 'src/enum/match.type.enum';
  * maxSpectatorCount: 최대 관전자 수
  */
 export class GameRoomCreateRequestDto {
+  @ApiProperty({
+    description: '게임방 모드 (비밀번호/초대전용/공개)',
+    example: GameRoomMode.PROTECTED,
+    enum: GameRoomMode,
+  })
   mode: GameRoomMode;
+
+  @ApiProperty({
+    description: '대전 유형',
+    example: MatchType.LADDER,
+    enum: MatchType,
+  })
   type: MatchType;
+
+  @ApiProperty({
+    description: '게임방 제목',
+    example: '게임방 제목입니다.',
+  })
   title: string;
+
+  @ApiProperty({
+    description: '게임방 비밀번호(optional)',
+    example: '1234',
+    required: false,
+  })
   password?: string;
+
+  @ApiProperty({
+    description: '최대 관전자 수',
+    example: 10,
+  })
   maxSpectatorCount: number;
 }

--- a/backend/src/dto/response/chatroom.list.response.dto.ts
+++ b/backend/src/dto/response/chatroom.list.response.dto.ts
@@ -1,11 +1,39 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { ChatRoomListDto } from '../chatroom.list.dto';
+import { ChatRoomMode } from 'src/enum/chatroom.mode.enum';
 
 /**
  * 현재 채팅방 목록을 반환하는 응답 DTO입니다.
  * chatRooms: 채팅방 리스트
- * isLast: 마지막 페이지인지 여부
  */
 export class ChatRoomListResponseDto {
+  @ApiProperty({
+    description: '현재 채팅방 목록, 로비에서 확인하는 목록입니다.',
+    example: [
+      {
+        roomId: 1,
+        title: '채팅방1',
+        mode: ChatRoomMode.PUBLIC,
+        maxUserCount: 10,
+        currentCount: 5,
+      },
+      {
+        roomId: 2,
+        title: '채팅방2',
+        mode: ChatRoomMode.PROTECTED,
+        maxUserCount: 10,
+        currentCount: 7,
+      },
+      {
+        roomId: 3,
+        title: '채팅방3',
+        mode: ChatRoomMode.PRIVATE,
+        maxUserCount: 10,
+        currentCount: 10,
+      },
+    ] as ChatRoomListDto[],
+    type: ChatRoomListDto,
+    isArray: true,
+  })
   chatRooms: ChatRoomListDto[]; // 채팅방 리스트
-  isLast: boolean; // 마지막 페이지인지 여부
 }

--- a/backend/src/dto/response/chatroom.users.info.response.dto.ts
+++ b/backend/src/dto/response/chatroom.users.info.response.dto.ts
@@ -1,3 +1,4 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { UserChatDto } from '../user.chat.dto';
 
 /**
@@ -6,6 +7,28 @@ import { UserChatDto } from '../user.chat.dto';
  * @property users 채팅방에 참여한 유저들의 정보
  */
 export class ChatroomUsersInfoResponseDto {
-  mastUserId: number; // 방장의 유저 id
-  users: UserChatDto[]; // 채팅방에 참여한 유저들의 정보
+  @ApiProperty({
+    description: '방장의 유저 ID',
+    example: 1,
+  })
+  mastUserId: number;
+
+  @ApiProperty({
+    description: '채팅방에 참여한 유저들의 정보',
+    example: [
+      {
+        userId: 1,
+        nickname: 'user1',
+        avatarUrl: 'http://example.com',
+      },
+      {
+        userId: 2,
+        nickname: 'user2',
+        avatarUrl: 'http://example.com',
+      },
+    ] as UserChatDto[],
+    type: UserChatDto,
+    isArray: true,
+  })
+  users: UserChatDto[];
 }

--- a/backend/src/dto/response/gameroom.list.response.dto.ts
+++ b/backend/src/dto/response/gameroom.list.response.dto.ts
@@ -1,10 +1,50 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { GameRoomListDto } from '../gameroom.list.dto';
+import { GameRoomStatus } from 'src/enum/gameroom.status.enum';
 
 /**
  * 현재 게임방 목록을 반환하는 응답 DTO입니다.
  * gameRooms: 게임방 리스트
- * isLast: 마지막 페이지인지 여부
  */
 export class GameRoomListResponseDto {
+  @ApiProperty({
+    description: '현재 게임방 목록, 로비에서 확인하는 목록입니다.',
+    example: [
+      {
+        roomId: 1,
+        redUser: {
+          userId: 1,
+          nickname: 'redUser',
+          avatarUrl: 'http://example.com',
+        },
+        blueUser: {
+          userId: 2,
+          nickname: 'blueUser',
+          avatarUrl: 'http://example.com',
+        },
+        maxSpectatorCount: 10,
+        curSpectatorCount: 5,
+        roomStatus: GameRoomStatus.ON_READY,
+      },
+      {
+        roomId: 2,
+        redUser: {
+          userId: 3,
+          nickname: 'redUser2',
+          avatarUrl: 'http://example.com',
+        },
+        blueUser: {
+          userId: 4,
+          nickname: 'blueUser2',
+          avatarUrl: 'http://example.com',
+        },
+        maxSpectatorCount: 10,
+        curSpectatorCount: 7,
+        roomStatus: GameRoomStatus.ON_GAME,
+      },
+    ] as GameRoomListDto[],
+    type: GameRoomListDto,
+    isArray: true,
+  })
   gameRooms: GameRoomListDto[];
 }

--- a/backend/src/dto/response/gameroom.users.info.response.dto.ts
+++ b/backend/src/dto/response/gameroom.users.info.response.dto.ts
@@ -1,3 +1,4 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { UserDto } from '../user.dto';
 
 /**
@@ -6,9 +7,41 @@ import { UserDto } from '../user.dto';
  * @property users 게임방에 참여한 유저들의 정보
  */
 export class GameRoomUsersInfoResponseDto {
-  roomId: number; // 게임방 ID
-  redUser: UserDto; // 빨간 팀 유저
-  blueUser: UserDto; // 파란 팀 유저
-  maxSpectatorCount: number; // 최대 관전자 수
-  curSpectatorCount: number; // 현재 관전자 수
+  @ApiProperty({
+    description: '게임방에 참여한 유저들의 정보',
+    example: 1,
+  })
+  roomId: number;
+
+  @ApiProperty({
+    description: '레드팀 유저 정보',
+    example: {
+      userId: 1,
+      nickname: 'redUser',
+      avatarUrl: 'http://example.com',
+    } as UserDto,
+  })
+  redUser: UserDto;
+
+  @ApiProperty({
+    description: '블루팀 유저 정보',
+    example: {
+      userId: 2,
+      nickname: 'blueUser',
+      avatarUrl: 'http://example.com',
+    } as UserDto,
+  })
+  blueUser: UserDto;
+
+  @ApiProperty({
+    description: '최대 관전자 수',
+    example: 10,
+  })
+  maxSpectatorCount: number;
+
+  @ApiProperty({
+    description: '현재 관전자 수',
+    example: 5,
+  })
+  curSpectatorCount: number;
 }

--- a/backend/src/dto/response/online.users.response.dto.ts
+++ b/backend/src/dto/response/online.users.response.dto.ts
@@ -1,9 +1,26 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { UserDto } from '../user.dto';
 
 /**
  * 현재 온라인인 유저들의 정보를 담는 DTO
  */
 export class OnlineUsersResponseDto {
-  onlineUsers: UserDto[]; // 현재 온라인인 유저들의 정보
-  isLast: boolean; // 마지막 페이지인지 여부
+  @ApiProperty({
+    description: '현재 온라인인 유저들의 정보',
+    example: [
+      {
+        userId: 1,
+        nickname: 'user1',
+        avatarUrl: 'http://example.com',
+      },
+      {
+        userId: 2,
+        nickname: 'user2',
+        avatarUrl: 'http://example.com',
+      },
+    ] as UserDto[],
+    type: UserDto,
+    isArray: true,
+  })
+  onlineUsers: UserDto[];
 }

--- a/backend/src/dto/response/rank.list.response.dto.ts
+++ b/backend/src/dto/response/rank.list.response.dto.ts
@@ -1,10 +1,41 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { RankDto } from '../rank.dto';
 
 /**
  * 순위 정보를 반환하는 dto입니다.
  * ranklist는 순위 정보 리스트를 저장합니다.
- * isLast는 마지막 페이지인지 여부를 저장합니다.
  */
 export class RankListResponseDto {
-  rankList: RankDto[]; // 순위 정보 리스트
+  @ApiProperty({
+    description: '순위 정보 리스트',
+    example: [
+      {
+        ranking: 1,
+        userInfo: {
+          userId: 1,
+          nickname: 'user1',
+          avatarUrl: 'http://example.com',
+        },
+        ladderScore: 1000,
+        winCount: 9,
+        loseCount: 1,
+        winRate: 90,
+      },
+      {
+        ranking: 2,
+        userInfo: {
+          userId: 2,
+          nickname: 'user2',
+          avatarUrl: 'http://example.com',
+        },
+        ladderScore: 900,
+        winCount: 8,
+        loseCount: 2,
+        winRate: 80,
+      },
+    ] as RankDto[],
+    type: RankDto,
+    isArray: true,
+  })
+  rankList: RankDto[];
 }

--- a/backend/src/dto/response/user.block.list.response.dto.ts
+++ b/backend/src/dto/response/user.block.list.response.dto.ts
@@ -1,11 +1,27 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { UserDto } from '../user.dto';
 
 /**
  * 유저가 차단한 유저 목록을 반환하는 dto입니다.
  * blockList 차단한 유저정보 리스트를 저장합니다.
- * isLast는 마지막 페이지인지 여부를 저장합니다.
  */
 export class UserBlockListResponseDto {
-  blockUsers: UserDto[]; // 차단 유저정보 리스트
-  isLast: boolean; // 마지막 페이지인지 여부
+  @ApiProperty({
+    description: '차단한 유저정보 리스트',
+    example: [
+      {
+        userId: 1,
+        nickname: 'blockUser1',
+        avatarUrl: 'http://example.com',
+      },
+      {
+        userId: 2,
+        nickname: 'blockUser2',
+        avatarUrl: 'http://example.com',
+      },
+    ] as UserDto[],
+    type: UserDto,
+    isArray: true,
+  })
+  blockUsers: UserDto[];
 }

--- a/backend/src/dto/response/user.friend.list.response.dto.ts
+++ b/backend/src/dto/response/user.friend.list.response.dto.ts
@@ -1,11 +1,27 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { UserDto } from '../user.dto';
 
 /**
  * 유저의 친구 목록을 반환하는 dto입니다.
  * friendList는 친구의 유저정보 리스트를 저장합니다.
- * isLast는 마지막 페이지인지 여부를 저장합니다.
  */
 export class UserFriendListResponseDto {
-  friendUsers: UserDto[]; // 친구의 유저정보 리스트
-  isLast: boolean; // 마지막 페이지인지 여부
+  @ApiProperty({
+    description: '친구의 유저정보 리스트',
+    example: [
+      {
+        userId: 1,
+        nickname: 'friendUser1',
+        avatarUrl: 'http://example.com',
+      },
+      {
+        userId: 2,
+        nickname: 'friendUser2',
+        avatarUrl: 'http://example.com',
+      },
+    ] as UserDto[],
+    type: UserDto,
+    isArray: true,
+  })
+  friendUsers: UserDto[];
 }

--- a/backend/src/dto/response/user.info.response.dto.ts
+++ b/backend/src/dto/response/user.info.response.dto.ts
@@ -1,5 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { UserStatusDto } from '../user.status.dto';
+import { UserStatus } from 'src/enum/user.status.enum';
 
 export class UserInfoResponseDto {
-  userInfo: UserStatusDto; // 유저 정보
+  @ApiProperty({
+    description: '상태를 포함하는 유저 정보',
+    example: {
+      userId: 1,
+      nickname: 'user',
+      avatarUrl: 'http://example.com',
+      status: UserStatus.ONLINE,
+    } as UserStatusDto,
+  })
+  userInfo: UserStatusDto;
 }

--- a/backend/src/dto/response/user.recent.match.history.response.dto.ts
+++ b/backend/src/dto/response/user.recent.match.history.response.dto.ts
@@ -1,5 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { MatchHistoryDto } from '../match.history.dto';
 import { UserDto } from '../user.dto';
+import { MatchResult } from 'src/enum/match.result.enum';
+import { MatchType } from 'src/enum/match.type.enum';
 
 /**
  * 유저의 최근 전적 기록을 반환하는 dto입니다.
@@ -7,6 +10,51 @@ import { UserDto } from '../user.dto';
  * matchHistories는 검색한 유저의 최근 전적 기록을 저장합니다.
  */
 export class UserRecentMatchHistoryResponseDto {
-  userInfo: UserDto; // 검색한 유저의 정보
-  matchHistories: MatchHistoryDto[]; // 검색한 유저의 최근 전적 기록
+  @ApiProperty({
+    description: '검색한 유저의 정보',
+    example: {
+      userId: 1,
+      nickname: 'user',
+      avatarUrl: 'http://example.com',
+    } as UserDto,
+    type: UserDto,
+  })
+  userInfo: UserDto;
+
+  @ApiProperty({
+    description: '검색한 유저의 최근 전적 기록',
+    example: [
+      {
+        matchId: 1,
+        matchResult: MatchResult.WIN,
+        opponent: {
+          userId: 2,
+          nickname: 'opponentUser',
+          avatarUrl: 'http://example.com',
+        } as UserDto,
+        myScore: 10,
+        opponentScore: 5,
+        beginDate: new Date('2023-02-15T00:00:00.000Z'),
+        matchTime: 282000,
+        matchType: MatchType.LADDER,
+      },
+      {
+        matchId: 2,
+        matchResult: MatchResult.LOSE,
+        opponent: {
+          userId: 3,
+          nickname: 'opponentUser2',
+          avatarUrl: 'http://example.com',
+        } as UserDto,
+        myScore: 5,
+        opponentScore: 10,
+        beginDate: new Date('2023-02-15T00:00:00.000Z'),
+        matchTime: 272000,
+        matchType: MatchType.LADDER,
+      },
+    ] as MatchHistoryDto[],
+    type: MatchHistoryDto,
+    isArray: true,
+  })
+  matchHistories: MatchHistoryDto[];
 }

--- a/backend/src/dto/user.chat.dto.ts
+++ b/backend/src/dto/user.chat.dto.ts
@@ -1,10 +1,16 @@
 import { UserChatMode } from 'src/enum/user.chat.mode.enum';
 import { UserDto } from './user.dto';
+import { ApiProperty } from '@nestjs/swagger';
 
 /**
  * 채팅방에 참여한 유저의 정보를 반환하는 dto입니다.
  * @property mode 유저의 채팅 모드
  */
 export class UserChatDto extends UserDto {
+  @ApiProperty({
+    description: '유저의 채팅 모드(방장/관리자/일반)',
+    example: UserChatMode.NORMAL,
+    enum: UserChatMode,
+  })
   mode: UserChatMode;
 }

--- a/backend/src/dto/user.dto.ts
+++ b/backend/src/dto/user.dto.ts
@@ -1,3 +1,5 @@
+import { ApiProperty } from '@nestjs/swagger';
+
 /**
  * pong 게임 유저의 정보를 저장합니다.
  * avatarUrl은 사용자의 프로필 사진을 저장합니다.
@@ -5,9 +7,34 @@
  * avatarUrl, email, firstLogin 필드는 확장성을 위해 optional로 설정되어 있습니다.
  */
 export class UserDto {
-  userId: number; // 유저의 ID
-  nickname: string; // 유저의 닉네임
-  avatarUrl?: string; // 아바타 이미지 url
+  @ApiProperty({
+    description: '유저의 ID',
+    example: 1,
+  })
+  userId: number;
+
+  @ApiProperty({
+    description: '유저의 닉네임',
+    example: 'user1',
+  })
+  nickname: string;
+
+  @ApiProperty({
+    description: '유저의 아바타 이미지 url',
+    example: 'http://example.com',
+  })
+  avatarUrl?: string;
+
+  @ApiProperty({
+    description: '유저의 이메일',
+    example: 'http://example.email.com',
+  })
   email?: string; // 유저의 이메일
+
+  @ApiProperty({
+    description: '유저의 첫 로그인 시간',
+    example: '2023-02-15T00:00:00.000Z',
+    type: Date,
+  })
   firstLogin?: Date; // 유저의 첫 로그인 시간
 }

--- a/backend/src/dto/user.status.dto.ts
+++ b/backend/src/dto/user.status.dto.ts
@@ -1,9 +1,15 @@
 import { UserStatus } from 'src/enum/user.status.enum';
 import { UserDto } from './user.dto';
+import { ApiProperty } from '@nestjs/swagger';
 
 /**
  * 상태를 포함한 유저의 정보를 반환하는 dto입니다.
  */
 export class UserStatusDto extends UserDto {
-  status: UserStatus; // 유저의 상태
+  @ApiProperty({
+    description: '유저의 상태(온라인/오프라인)',
+    example: UserStatus.ONLINE,
+    enum: UserStatus,
+  })
+  status: UserStatus;
 }

--- a/backend/src/enum/user.status.enum.ts
+++ b/backend/src/enum/user.status.enum.ts
@@ -4,7 +4,7 @@
  * OFFLINE: 오프라인
  * NOTE: 상태가 추가될 경우 이곳에 추가합니다.
  */
-export class UserStatus {
-  ONLINE = 'ONLINE';
-  OFFLINE = 'OFFLINE';
+export enum UserStatus {
+  ONLINE = 'ONLINE',
+  OFFLINE = 'OFFLINE',
 }

--- a/backend/src/mock/mock.repository.ts
+++ b/backend/src/mock/mock.repository.ts
@@ -7,7 +7,6 @@ import { UserBlockListResponseDto } from '../dto/response/user.block.list.respon
 export class MockRepository {
   getOnlineUser(USER_NUM: number) {
     let ret: OnlineUsersResponseDto;
-    ret.isLast = true;
     for (let i = 0; i < USER_NUM; ++i) {
       ret.onlineUsers.push({
         userId: i,
@@ -21,7 +20,6 @@ export class MockRepository {
 
   getFriendUser(USER_NUM: number) {
     let ret: UserFriendListResponseDto;
-    ret.isLast = true;
     for (let i = 0; i < USER_NUM; ++i) {
       ret.friendUsers.push({
         userId: i,
@@ -35,7 +33,6 @@ export class MockRepository {
 
   getBlockUser(USER_NUM: number) {
     let ret: UserBlockListResponseDto;
-    ret.isLast = true;
     for (let i = 0; i < USER_NUM; ++i) {
       ret.blockUsers.push({
         userId: i,


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>중대한 사항이라면 상세히 적어주세요.

<img width="795" alt="스크린샷 2023-02-15 오후 4 30 10" src="https://user-images.githubusercontent.com/83565255/218961098-55d92d69-76a5-4943-a37f-5df49ca00f90.png">

이런식으로 Controller 함수 위에 `ApiOkResponse`에 type으로 명세할 DTO를 기입하면,

<img width="1350" alt="스크린샷 2023-02-15 오후 4 31 30" src="https://user-images.githubusercontent.com/83565255/218961364-6c505fc1-d9e4-4cf0-ae20-c11372a27f45.png">

swagger 페이지에서 이런 형식으로 200응답이 왔을 때의 예시를 확인할 수 있습니다.
200 OK 응답뿐만아니라 201(ApiCreatedResponse)이나 204(ApiNoContentResponse) 등 성공 응답에 대해서 명세가 가능하고,
실패 시 응답도 400(ApiBadRequestResponse) 등으로 명세가 가능합니다.
