### PR TITLE
[BE] FIX: Blob 형태의 파일 업로드 버그 수정 #128

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 dist
 *.env
+backend/uploads

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -31,7 +31,7 @@ import { join } from 'path';
     EventEmitterModule.forRoot(),
     ServeStaticModule.forRoot({
       rootPath: join(__dirname, '..', 'uploads'),
-      serveRoot: '/static',
+      serveRoot: '/uploads',
     }),
     AuthModule,
     UserModule,

--- a/backend/src/config/configuration.ts
+++ b/backend/src/config/configuration.ts
@@ -1,5 +1,6 @@
 export default () => ({
   fe_host: process.env.FE_HOST,
+  be_host: process.env.BE_HOST,
   port: parseInt(process.env.PORT, 10),
   debug: {
     log: process.env.DEBUG_LOG === 'true' ? true : false,

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -113,12 +113,6 @@ export class UserController {
   @Patch('update')
   @UseInterceptors(
     FileInterceptor('avatarImage', {
-      fileFilter: (req, file, cb) => {
-        if (!file.originalname.match(/\.(jpg|jpeg|png|gif|svg|ico)$/)) {
-          return cb(new Error('지원되지 않는 확장자입니다.'), false);
-        }
-        cb(null, true);
-      },
       storage: diskStorage({
         destination: (req, file, cb) => {
           const path = `uploads`;
@@ -128,7 +122,7 @@ export class UserController {
           cb(null, path);
         },
         filename: (req, file, cb) => {
-          cb(null, `${uuid()}-${file.originalname}`);
+          cb(null, `${uuid()}.${file.mimetype.split('/')[1]}`);
         },
       }),
     }),

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -9,7 +9,7 @@ import {
   Logger,
   Param,
   ParseIntPipe,
-  Patch,
+  Post,
   Res,
   UploadedFile,
   UseGuards,
@@ -98,7 +98,7 @@ export class UserController {
       '유저 정보를 업데이트합니다. 닉네임 혹은 아바타 이미지를 변경할 수 있습니다.',
   })
   @ApiResponse({
-    status: 200,
+    status: 201,
     description: '유저 정보 업데이트에 성공했습니다.',
   })
   @ApiResponse({
@@ -109,8 +109,8 @@ export class UserController {
     status: 404,
     description: '존재하지 않는 유저입니다.',
   })
-  @HttpCode(200)
-  @Patch('update')
+  @HttpCode(201)
+  @Post('update')
   @UseInterceptors(
     FileInterceptor('avatarImage', {
       storage: diskStorage({
@@ -142,7 +142,9 @@ export class UserController {
 
     // 아바타 이미지가 변경된 경우, 파일 경로를 저장합니다.
     if (avatarImage) {
-      newAvatarUrl = avatarImage.path;
+      newAvatarUrl = `${this.configService.get<string>('be_host')}/${
+        avatarImage.path
+      }`;
     }
 
     const userInfo = await this.userService.updateUserInfo(
@@ -167,6 +169,6 @@ export class UserController {
         domain,
       });
     }
-    res.status(HttpStatus.OK).send();
+    res.status(HttpStatus.CREATED).send();
   }
 }

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -16,13 +16,11 @@ export const updateUserInfoAPI = async (
   avatarImage?: File
 ) => {
   if (avatarImage) {
-    const formData = new FormData();
-    formData.append("file", avatarImage);
     const response = await patchRequest(
       "users/update",
       {
         nickname,
-        formData,
+        avatarImage,
       },
       {
         headers: {

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -1,4 +1,4 @@
-import { deleteRequest, getRequest, patchRequest } from "./axios";
+import { deleteRequest, getRequest, patchRequest, postRequest } from "./axios";
 
 // TODO: 실패 처리
 export const getOnlineUsersAPI = async () => {
@@ -16,21 +16,18 @@ export const updateUserInfoAPI = async (
   avatarImage?: File
 ) => {
   if (avatarImage) {
-    const response = await patchRequest(
-      "users/update",
-      {
-        nickname,
-        avatarImage,
+    const formData = new FormData();
+    formData.append("avatarImage", avatarImage);
+    formData.append("nickname", nickname);
+
+    const response = await postRequest("users/update", formData, {
+      headers: {
+        "Content-Type": "multipart/form-data",
       },
-      {
-        headers: {
-          "Content-Type": "multipart/form-data",
-        },
-      }
-    );
+    });
     return response;
   } else {
-    const response = await patchRequest("users/update", {
+    const response = await postRequest("users/update", {
       nickname,
     });
     return response;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -77,6 +77,11 @@ server {
     proxy_set_header Host $host;
   }
 
+  location ^~ /uploads {
+    proxy_pass http://host.docker.internal:3000;
+    proxy_set_header Host $host;
+  }
+
    location ^~ /socket {
     proxy_pass http://host.docker.internal:3000;
     proxy_set_header Host $host;


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>중대한 사항이라면 상세히 적어주세요.

Blob 형태의 파일 업로드가 안되는 오류를 수정했습니다.
Nest에서 `FormData`로 감싸져오는 이미지를 받으면 undefined로 찍히는 오류가 있어,
Blob 파일을 그대로 전송하도록 수정하고, 저장할 때 `mimetype` 필드에 있는 확장자로 저장하도록 수정했습니다.

<img width="697" alt="스크린샷 2023-02-21 오전 12 20 27" src="https://user-images.githubusercontent.com/83565255/220144978-82cb1c22-4bf3-4672-8ec7-04256fd199ec.png">


또한, 이미지 파일 접근 url을 /static -> /uploads로 변경했습니다.
이제 아래와 같은 경로로 접근해야 합니다..!
http://localhost/uploads/c18d9d87-8942-4c9a-8dfd-8098788f2f2a.png


<img width="519" alt="스크린샷 2023-02-21 오전 12 33 07" src="https://user-images.githubusercontent.com/83565255/220147609-09e1ee3a-342f-4dad-bea7-292a8ab0af96.png">
또한 로비에서 이미지를 불러올 때, 위와같이
http://localhost/lobby/uploads/c18d9d87-8942-4c9a-8dfd-8098788f2f2a.png 형태로 불러오고 있습니다.
http://localhost/uploads/c18d9d87-8942-4c9a-8dfd-8098788f2f2a.png 형태로 가져오도록 수정해주시기 바랍니다!

nginx.conf도 /uploads로 보내는 요청을 백엔드로 Proxy_pass 하도록 수정했습니다.