### PR TITLE
[FE] FEAT: axios error 처리 #139

### DIFF
--- a/frontend/src/api/ranking.ts
+++ b/frontend/src/api/ranking.ts
@@ -12,5 +12,6 @@ export const getRankListAPI = async (
   const response = await getRequest(
     `stat/ranking/?filter=${filter}&order=${order}`
   );
+  console.log(response);
   return response.data.rankList;
 };

--- a/frontend/src/components/modules/UnauthorizedModal/UnauthorizedModal.tsx
+++ b/frontend/src/components/modules/UnauthorizedModal/UnauthorizedModal.tsx
@@ -1,0 +1,58 @@
+import { useNavigate } from "react-router-dom";
+import { useSetRecoilState } from "recoil";
+import styled from "styled-components";
+import errorState from "../../../state/ErrorState";
+import Board from "../../atoms/Board";
+import Button from "../../atoms/Button";
+import Modal from "../../atoms/Modal";
+import ModalWrapper from "../../atoms/ModalWrapper";
+import Typography from "../../atoms/Typography";
+import ModalTitle from "../ModalTitle";
+
+const Wrapper = styled(Board).attrs((props) => {
+  return {
+    backgroundColor: props.theme.background.middle,
+    width: "100%",
+    height: "51%",
+    borderRadius: true,
+    flexDirection: "column",
+    justifyContent: "space-around",
+  };
+})``;
+
+const ErrorMessage = styled(Typography).attrs({
+  fontSize: "2rem",
+})`
+  color: yellow;
+`;
+
+const ModalButton = styled(Button).attrs({
+  width: "50%",
+  height: "20%",
+})``;
+
+const UnauthorizedModal = () => {
+  const navigate = useNavigate();
+  const setError = useSetRecoilState(errorState);
+
+  const onClose = () => {
+    navigate("/");
+    setError(false);
+  };
+
+  return (
+    <ModalWrapper backgroundColor="black">
+      <Modal width="30%" height="30%">
+        <ModalTitle onClose={onClose} height="25%" fontSize="2rem">
+          로그인 인증 필요
+        </ModalTitle>
+        <Wrapper>
+          <ErrorMessage>로그인이 필요한 서비스입니다</ErrorMessage>
+        </Wrapper>
+        <ModalButton onClick={onClose}>로그인 화면으로</ModalButton>
+      </Modal>
+    </ModalWrapper>
+  );
+};
+
+export default UnauthorizedModal;

--- a/frontend/src/components/modules/UnauthorizedModal/index.tsx
+++ b/frontend/src/components/modules/UnauthorizedModal/index.tsx
@@ -1,0 +1,1 @@
+export { default } from "./UnauthorizedModal";

--- a/frontend/src/pages/Lobby.tsx
+++ b/frontend/src/pages/Lobby.tsx
@@ -13,6 +13,8 @@ import useFirstLoginModal from "../hooks/useFirstLoginModal";
 import useLoading from "../hooks/useLoading";
 import FullSpinner from "../components/atoms/FullSpinner";
 import useLobbyData from "../hooks/useLobbyData";
+import { useSetRecoilState } from "recoil";
+import errorState from "../state/ErrorState";
 
 const UserWrapper = styled(Board).attrs({
   width: "25%",
@@ -42,7 +44,6 @@ const RoomListChat = styled(Board).attrs((props) => {
   };
 })``;
 
-// TODO: 소켓 이벤트 등록하기  => LobbyUserList 파일 주석 확인
 const Lobby = () => {
   const { setLobbyData, getLobbyData } = useLobbyData();
   const { isLoading, endLoading } = useLoading({
@@ -52,9 +53,11 @@ const Lobby = () => {
   const { onlineUsers, friendUsers, blockUsers, chatRoomList, myInfo } =
     getLobbyData();
   const { isFirstLoginModal, FirstLoginModalClose } = useFirstLoginModal();
+  const setError = useSetRecoilState(errorState);
+
   useEffect(() => {
     (async () => {
-      await setLobbyData();
+      await setLobbyData().catch(() => setError(true));
       endLoading();
     })();
   }, []);

--- a/frontend/src/pages/Root.tsx
+++ b/frontend/src/pages/Root.tsx
@@ -1,5 +1,8 @@
 import { Outlet } from "react-router-dom";
+import { useRecoilValue } from "recoil";
 import styled from "styled-components";
+import UnauthorizedModal from "../components/modules/UnauthorizedModal";
+import errorState from "../state/ErrorState";
 
 const RootStyled = styled.div`
   background-color: ${(props) => props.theme.colors.chineseWhite};
@@ -11,10 +14,15 @@ const RootStyled = styled.div`
 `;
 
 const Root = () => {
+  const error = useRecoilValue(errorState);
+
   return (
-    <RootStyled>
-      <Outlet />
-    </RootStyled>
+    <>
+      <RootStyled>
+        <Outlet />
+      </RootStyled>
+      {error && <UnauthorizedModal />}
+    </>
   );
 };
 

--- a/frontend/src/state/ErrorState.tsx
+++ b/frontend/src/state/ErrorState.tsx
@@ -1,0 +1,8 @@
+import { atom } from "recoil";
+
+const errorState = atom<boolean>({
+  key: "errorState",
+  default: false,
+});
+
+export default errorState;

--- a/frontend/src/utils/cookie.ts
+++ b/frontend/src/utils/cookie.ts
@@ -1,10 +1,18 @@
 export const getCookie = () => {
-  const cookie = document.cookie.split("=")?.[1];
-  return cookie;
+  const cookies = document.cookie.split(";");
+  for (let i = 0; i < cookies.length; i++) {
+    const cookie = cookies[i].trim();
+    if (cookie.startsWith(`${import.meta.env.VITE_JWT_TOKEN}=`)) {
+      return cookie.substring(import.meta.env.VITE_JWT_TOKEN.length + 1);
+    }
+  }
+  return null;
 };
 
 export const getDecodedCookie = () => {
   const cookie = getCookie();
+  if (!cookie) throw new Error();
+
   const payload = cookie.split(".")[1];
   const decoded = window.atob(payload);
   return decoded;


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>중대한 사항이라면 상세히 적어주세요.
close #139 
axios 요청 시 에러가 나면 로그인 화면으로 돌아가게 했습니다.
<img width="1487" alt="image" src="https://user-images.githubusercontent.com/74703501/220815005-779f3d2e-ab5b-44f1-a5e5-c242e6a3f764.png">

stat, ranking 페이지 api 요청시 401 응답이 필요합니다.