### PR TITLE
[BE] FIX: 게임방 관련 버그 수정 #191

### DIFF
--- a/backend/src/chat/chat.geteway.ts
+++ b/backend/src/chat/chat.geteway.ts
@@ -19,6 +19,7 @@ import { ChangeChatroomInfoRequestDto } from 'src/dto/request/chatroom.change.in
 import { UserChatMode } from 'src/enum/user.chat.mode.enum';
 import { UserChatDto } from 'src/dto/user.chat.dto';
 import { ChatRoomMode } from 'src/enum/chatroom.mode.enum';
+import { GameRoomService } from 'src/game/gameroom.service';
 export const rooms = new Map<number, Room>();
 let roomCount = 1;
 
@@ -44,11 +45,9 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
   eventEmitter = new EventEmitter2();
   muteUsers = new Array<number>();
 
-  // private readonly userService: UserService;
   constructor(
-    private readonly chatService: ChatroomService,
-    //@Inject(UserService)
     private readonly userService: UserService,
+    private readonly gameRoomService: GameRoomService,
   ) {}
 
   @WebSocketServer() server: Namespace;
@@ -59,6 +58,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
       // 끊긴 소켓 삭제
       users.forEach((value, key, map) => {
         if (socket.id == value.socketId) {
+          // 채팅방 소켓 정리
           if (value.location > 0) {
             for (let i = 0; i < rooms.get(value.location).users.length; i++) {
               if (rooms.get(value.location).users[i] == value.userId) {
@@ -69,6 +69,9 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
                 break;
               }
             }
+          } else {
+            // 게임방 소켓 정리
+            this.gameRoomService.disconnectUser(value);
           }
           this.server.to('lobby').emit('deleteOnlineUser', key);
           users.delete(key);
@@ -79,7 +82,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
   }
   //연결 끊김
   async handleDisconnect(client) {
-    console.log('disconnect');
+    this.logger.log(`Called ${this.handleDisconnect.name}`);
   }
 
   @SubscribeMessage('addUser')
@@ -97,9 +100,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
       user = new User(info.userId, info.userName);
     }
     user.socketId = client.id;
-    console.log(user);
     users.set(info.userId, user);
-    console.log(users);
 
     // 로비 채팅방에 유저 추가
     client.join('lobby');
@@ -185,6 +186,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
   @OnEvent('chatroom:leave')
   async leaveChatRoom(roomId, userId) {
     const room = rooms.get(roomId);
+    if (!room) return;
     if (room.masterUser === userId) {
       this.server.in(`chatroom${roomId}`).emit('destructChatRoom');
       this.server.in(`chatroom${roomId}`).socketsJoin('lobby');

--- a/backend/src/chat/chat.module.ts
+++ b/backend/src/chat/chat.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { ChatGateway } from './chat.geteway';
 import { ChatroomController } from './chatroom.controller';
 import { ChatroomService } from './chat.service';
@@ -6,8 +6,13 @@ import { repo, UserModule } from 'src/user/user.module';
 import { UserService } from 'src/user/user.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import User from 'src/entity/user.entity';
+import { GameModule } from 'src/game/game.module';
 @Module({
-  imports: [UserModule, TypeOrmModule.forFeature([User])],
+  imports: [
+    UserModule,
+    TypeOrmModule.forFeature([User]),
+    forwardRef(() => GameModule),
+  ],
   providers: [ChatGateway, ChatroomService, repo],
   exports: [ChatGateway, ChatroomService],
   controllers: [ChatroomController],

--- a/backend/src/game/game.gateway.ts
+++ b/backend/src/game/game.gateway.ts
@@ -36,10 +36,6 @@ import { MatchHistoryDto } from 'src/dto/match.history.dto';
 import { StatService } from 'src/stat/stat.service';
 
 export const gameRooms = new Map<number, GameRoom>();
-export let invitations: Invitation[] = [];
-
-// export const normalQuickMatchQueue = new Array<number>();
-// export const ladderQuickMatchQueue = new Array<number>();
 
 @WebSocketGateway({
   namespace: 'socket/game',
@@ -49,9 +45,6 @@ export class GameGateway implements OnGatewayDisconnect {
   private logger = new Logger(GameGateway.name);
   //
   constructor(
-    private readonly jwtService: JwtService,
-    private readonly authService: AuthService,
-    private readonly configService: ConfigService,
     private readonly userService: UserService,
     private readonly eventEmitter: EventEmitter2,
     private readonly gameRoomService: GameRoomService,
@@ -71,26 +64,8 @@ export class GameGateway implements OnGatewayDisconnect {
     // 끊긴 소켓 삭제
     const userSocketInfo = users.get(socket.id);
     if (userSocketInfo) {
-      gameRooms.forEach((_, roomId) => {
-        if (
-          this.gameRoomService.isOnThatGameRoom(
-            roomId + 1,
-            userSocketInfo.userId,
-          )
-        ) {
-          this.eventEmitter.emit(
-            'gameroom:leave',
-            roomId + 1,
-            userSocketInfo.userId,
-          );
-        }
-      });
-      // 초대장을 가지고 있다면 삭제
-      invitations = invitations.filter(
-        (invitation) =>
-          invitation.inviteeId !== userSocketInfo.userId &&
-          invitation.inviterId !== userSocketInfo.userId,
-      );
+      console.log('disconnect gameroom user: ', userSocketInfo);
+      this.gameRoomService.disconnectUser(userSocketInfo);
     }
   }
 
@@ -180,7 +155,9 @@ export class GameGateway implements OnGatewayDisconnect {
     const user = room.redUser.userId === userId ? room.redUser : room.blueUser;
     const userSocketInfo = users.get(user.userId);
     //gameInstance 종료 이벤트
-    await this.eventEmitter.emitAsync('gameroom:finish', roomId);
+    if (room.status === GameRoomStatus.ON_GAME) {
+      await this.eventEmitter.emitAsync('gameroom:finish', roomId);
+    }
     if (user.userId === room.redUser.userId) {
       this.server.in(`gameroom-${room.roomId}`).emit('destructGameRoom');
       this.chatGateway.server
@@ -216,13 +193,11 @@ export class GameGateway implements OnGatewayDisconnect {
     const userSocketInfo = users.get(userId);
 
     // 초대장을 생성
-    invitations.push({
-      invitationId: invitations.length + 1,
-      inviterId: userId,
-      inviteeId: targetUserId,
-      matchType: matchType,
-      expirationTime: new Date(new Date().getTime() + 1000 * 60),
-    });
+    const invitation = this.gameRoomService.createInvitation(
+      userId,
+      targetUserId,
+      matchType,
+    );
 
     // 초대장을 받은 유저에게 초대장을 전달
     // FIXME: 초대장에 어떤 내용을 담을지 협의 필요
@@ -233,9 +208,7 @@ export class GameGateway implements OnGatewayDisconnect {
 
     // 1분 후 초대장이 남아있다면 초대장을 삭제
     setTimeout(() => {
-      invitations = invitations.filter(
-        (invitation) => invitation.invitationId !== invitations.length,
-      );
+      this.gameRoomService.deleteInvitationById(invitation);
     }, 1000 * 60);
   }
 
@@ -246,9 +219,7 @@ export class GameGateway implements OnGatewayDisconnect {
     const inviteeSocketInfo = users.get(userId);
 
     // 초대장 정보
-    const invitation = invitations.find(
-      (invitation) => invitation.inviteeId === userId,
-    );
+    const invitation = this.gameRoomService.findInvitationByInviteeId(userId);
 
     // 초대한 사람의 socket 정보
     const inviterId = invitation.inviterId;
@@ -304,9 +275,7 @@ export class GameGateway implements OnGatewayDisconnect {
     this.server.in(`gameroom-${roomId}`).emit('gameRoomMatched', gameRoom);
 
     // 초대장을 삭제
-    invitations = invitations.filter(
-      (invitation) => invitation.inviteeId !== userId,
-    );
+    this.gameRoomService.deleteInvitaionByInviteeId(userId);
 
     // 게임방에 입장한 유저들에게 입장 메시지를 보냅니다.
     this.server
@@ -326,16 +295,13 @@ export class GameGateway implements OnGatewayDisconnect {
     // 초대받은 사람의 socket 정보
     const inviteeSocketInfo = users.get(userId);
 
-    const inviterId = invitations.find(
-      (invitation) => invitation.inviteeId === userId,
-    ).inviterId;
+    const inviterId =
+      this.gameRoomService.findInvitationByInviteeId(userId).inviterId;
     // 초대한 사람의 socket 정보
     const inviterSocketInfo = users.get(inviterId);
 
     // inviteeId가 userId인 초대장을 삭제
-    invitations = invitations.filter(
-      (invitation) => invitation.inviteeId !== userId,
-    );
+    this.gameRoomService.deleteInvitaionByInviteeId(userId);
 
     // 초대한 사람에게 초대 거절을 알림
     this.server.in(inviterSocketInfo.gameSocketId).emit('rejectInviteGameRoom');
@@ -518,6 +484,10 @@ export class GameGateway implements OnGatewayDisconnect {
   async onGameFinish(roomId: number) {
     this.logger.log(`Called ${this.onGameFinish.name}`);
     const room = gameRooms.get(roomId);
+    // 유저를 unready 상태로 변경
+    this.eventEmitter.emit('gameroom:unready', roomId, room.redUser?.userId);
+    this.eventEmitter.emit('gameroom:unready', roomId, room.blueUser?.userId);
+
     //전적 처리를 위한 게임 결과 정보 반환
     const gameResult = room.gameInstance.finishGame();
     room.gameInstance = null;

--- a/backend/src/game/game.module.ts
+++ b/backend/src/game/game.module.ts
@@ -22,11 +22,11 @@ import { StatModule } from 'src/stat/stat.module';
     }),
     AuthModule,
     UserModule,
-    ChatModule,
+    forwardRef(() => ChatModule),
     StatModule,
   ],
   providers: [GameGateway, GameRoomService],
-  exports: [GameGateway],
+  exports: [GameGateway, GameRoomService],
   controllers: [GameRoomController],
 })
 export class GameModule {}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>중대한 사항이라면 상세히 적어주세요.

1. 방장이 게임방 나가기 api를 호출하지 않고 브라우저를 닫았을 경우 게임방이 사라지지 않는 오류
   `handleDisconnect` 부분에서 게임방에 입장한 경우 `gameroom:leave` 이벤트를 발생시키도록 처리했습니다.
    다만 채팅방 소켓이 먼저 끊어질 수도 있으므로 채팅방 쪽 disconnect 부분에서도 마찬가지로 적용했습니다.
    해당 버그 수정 과정에서 `Invitation` 객체를 `GameroomService`에서만 접근하도록 수정했습니다. 
    추후 전역으로 사용되는 변수들(Room, ChatRoom, User 등)도 마찬가지로 Service layer에서만 접근가능하도록 수정하는 것이 좋을 것 같습니다..!
3. 게임 끝나면 유저의 게임 유저의 레디 상태가 변경되지 않는 오류
    `onGameFinish`에서 게임 종료 후 `gameroom:unready` 이벤트를 발생시켜 유저들의 상태를 unready로 변경시키도록 했습니다.