### PR TITLE
[BE] FIX: 채팅 룸이 제거되지 않고 남아있는 문제 수정

### DIFF
--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -82,13 +82,18 @@ export class ChatroomService {
     chatrooms.chatRooms = [];
     for (const room of rooms.values()) {
       if (room.roomId !== 0) {
-        chatrooms.chatRooms.push({
-          roomId: room.roomId,
-          title: room.title,
-          mode: room.mode,
-          maxUserCount: room.maxUser,
-          currentCount: room.users.length,
-        });
+        if (room.users.length === 0) {
+          // 방의 목록을 출력하는 상황이 되었을 때 Lazy하게 빈 방을 제거
+          rooms.delete(room.roomId);
+        } else {
+          chatrooms.chatRooms.push({
+            roomId: room.roomId,
+            title: room.title,
+            mode: room.mode,
+            maxUserCount: room.maxUser,
+            currentCount: room.users.length,
+          });
+        }
       }
     }
     return chatrooms;


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
> 기존 비정상적인 이동에 의해 채팅방이 제거되지 않고 남아있는 문제가 있었습니다.
> 폴링 등 여러 방법을 통한 메모리 관리가 가능하지만, 기존 로직에서 반복문으로 채팅방 배열을 순회하는 부분이 있어,
> Lazy한 가비지 컬렉팅으로 불필요한 연산을 늘이지 않고, 제거된 방이 표시될 수 있도록 수정했습니다.
