### PR TITLE
[BE] FIX: user 정보가 캐싱되지 않는 버그 수정 #215

### DIFF
--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -160,7 +160,11 @@ export class UserController {
     );
     // nickname이 변경된 경우, JWT 토큰을 재발급하고, 캐싱된 유저 정보를 업데이트합니다.
     if (newNickname) {
-      await this.cacheManager.set(`user-${user.userId}`, userInfo, 60 * 10);
+      await this.cacheManager.set(
+        `user-${user.userId}`,
+        userInfo,
+        60 * 10 * 1000,
+      );
 
       const token = this.jwtService.sign({
         userId: user.userId,

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -57,7 +57,7 @@ export class UserService {
     let userInfo = await this.cacheManager.get<UserDto>(`user-${userId}`);
     if (!userInfo) {
       userInfo = await this.userRepository.getUserInfo(userId);
-      await this.cacheManager.set(`user-${userId}`, userInfo, 60 * 10);
+      await this.cacheManager.set(`user-${userId}`, userInfo, 60 * 10 * 1000);
     }
     return userInfo;
   }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>중대한 사항이라면 상세히 적어주세요.

#216 유저 정보가 캐싱되지 않는 버그가 있었는데, 원인은 캐싱의 `ttl(time-to-live)`시간의 단위가 '초'인줄 알고 60 * 10을 적었는데,
알고보니 'ms' 단위여서 0.6초만에 삭제되고 있었던거였네요.....
60 * 10 * 1000으로 바꾸어 10분동안 지속될 수 있도록 수정했습니다..!
