### PR TITLE
[BE] FIX: 유저가 존재하지 않을 때, 유저 상세정보 API 오류 수정

### DIFF
--- a/backend/src/stat/repository/stat.repository.ts
+++ b/backend/src/stat/repository/stat.repository.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@nestjs/common';
+import { Logger, NotFoundException } from '@nestjs/common';
 import { IStatRepository } from './stat.repository.interface';
 import { InjectRepository } from '@nestjs/typeorm';
 import MatchHistory from 'src/entity/match.history.entity';
@@ -163,6 +163,9 @@ export class StatRepository implements IStatRepository {
       ])
       .where('ladder_stat.userId = :userId', { userId })
       .getRawOne();
+    if (!result) {
+      throw new NotFoundException('해당 유저의 래더 게임 전적이 없습니다.');
+    }
     return {
       matchType: MatchType.LADDER,
       winCount: result.wincount,
@@ -185,6 +188,9 @@ export class StatRepository implements IStatRepository {
       ])
       .where('normal_stat.userId = :userId', { userId })
       .getRawOne();
+    if (!result) {
+      throw new NotFoundException('해당 유저의 일반 게임 전적이 없습니다.');
+    }
     return {
       matchType: MatchType.NORMAL,
       winCount: result.wincount,

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -84,7 +84,8 @@ export class UserController {
   })
   @ApiResponse({
     status: 404,
-    description: '존재하지 않는 유저입니다.',
+    description:
+      '존재하지 않는 유저이거나 래더/일반 게임 전적이 존재하지 않습니다.',
   })
   @Get(':user_id')
   async getUserDetail(

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -4,6 +4,7 @@ import {
   Inject,
   Injectable,
   Logger,
+  NotFoundException,
 } from '@nestjs/common';
 import { UserDto } from 'src/dto/user.dto';
 import { IUserRepository } from './repository/user.repository.interface';
@@ -65,6 +66,7 @@ export class UserService {
   async getUserDetail(userId: number): Promise<UserDetailResponseDto> {
     this.logger.debug(`Called ${this.getUserDetail.name}`);
     const userDto: UserDto = await this.getUserInfo(userId);
+    if (!userDto) throw new NotFoundException('유저가 존재하지 않습니다.');
     const [ladderInfo, normalInfo] = await this.statService.getUserGameStat(
       userId,
     );


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>중대한 사항이라면 상세히 적어주세요.

오류가 발생하는 원인은 유저 정보를 조회할 때 캐싱된 정보를 보여주기 때문입니다.
유저가 생성되고 난 후 캐싱은 10분간 지속이 되는데, 10분 사이에 유저를 DB에서 삭제하게 되면 캐싱은 그대로 남아있게 됩니다
캐싱된 정보를 바탕으로 유저의 래더/일반 게임 stat을 조회하면 조회 결과가 undefined로 반환되어 에러가 발생합니다.
딱히 유저를 제거하는 API는 제공하고 있지 않기 때문에 애초에 DB에서 삭제하는 것 자체가 정의되지 않은 동작이기 때문에 크게 고려할 사항은 아니긴 하지만, undefined를 받으면 404 Not Found Exception을 던져 예외처리를 해두었습니다.