### PR TITLE
[BE] REFACT: login/callback에서의 동작을 리팩토링

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -3,6 +3,7 @@ import { Cache } from 'cache-manager';
 import { UserDto } from 'src/dto/user.dto';
 import { IAuthRepository } from './repository/auth.repository.interface';
 import { UserAuthDto } from 'src/dto/user.auth.dto';
+import * as uuid62 from 'uuid62';
 
 @Injectable()
 export class AuthService {
@@ -15,21 +16,43 @@ export class AuthService {
 
   async addUserIfNotExists(user: UserDto): Promise<[UserAuthDto, boolean]> {
     this.logger.debug(`Called ${this.addUserIfNotExists.name}`);
-    const [userInfo, isFirstLogin] =
-      await this.authRepository.addUserIfNotExists(user);
-    await this.cacheManager.set(`auth-${user.userId}`, true, 0);
-    return [userInfo, isFirstLogin];
+    let userAuthInfo = await this.getUserAuthInfoById(user.userId);
+    let isFirstLogin = false;
+    if (!userAuthInfo) {
+      isFirstLogin = true;
+      // 해당 닉네임을 가진 유저가 이미 존재하는지 확인
+      const find = await this.authRepository.findUserByNickname(user.nickname);
+      // 이미 존재하면 유저를 Insert할 때, 닉네임으로 uuid를 사용
+      if (find) {
+        user.nickname = uuid62.v4();
+      }
+      userAuthInfo = await this.authRepository.addNewUser(user);
+      await this.cacheManager.set(
+        `auth-${user.userId}`,
+        userAuthInfo,
+        60 * 10 * 1000,
+      );
+    }
+    return [userAuthInfo, isFirstLogin];
   }
 
-  async checkUserExists(userId: number): Promise<boolean> {
-    this.logger.debug(`Called ${this.checkUserExists.name}`);
-    const exist = await this.cacheManager.get<boolean>(`auth-${userId}`);
-    if (exist === undefined) {
-      const result = await this.authRepository.checkUserExists(userId);
-      await this.cacheManager.set(`auth-${userId}`, true, 0);
-      return result;
+  async getUserAuthInfoById(userId: number): Promise<UserAuthDto> {
+    this.logger.debug(`Called ${this.getUserAuthInfoById.name}`);
+    let userAuthInfo = await this.cacheManager.get<UserAuthDto>(
+      `auth-${userId}`,
+    );
+    if (!userAuthInfo) {
+      userAuthInfo = await this.authRepository.getUserAuthInfoById(userId);
+      if (!userAuthInfo) {
+        return null;
+      }
+      await this.cacheManager.set(
+        `auth-${userId}`,
+        userAuthInfo,
+        60 * 10 * 1000,
+      );
     }
-    return exist;
+    return userAuthInfo;
   }
 
   async enroll2FA(userId: number): Promise<void> {

--- a/backend/src/auth/jwt/jwt.strategy.ts
+++ b/backend/src/auth/jwt/jwt.strategy.ts
@@ -27,7 +27,7 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
    * 유저가 DB에 존재하지 않는다면 인증을 거부합니다.
    */
   async validate(payload: any) {
-    const exist = await this.authService.checkUserExists(payload.userId);
+    const exist = await this.authService.getUserAuthInfoById(payload.userId);
     if (!exist) {
       return false;
     }

--- a/backend/src/auth/repository/auth.repository.interface.ts
+++ b/backend/src/auth/repository/auth.repository.interface.ts
@@ -3,20 +3,25 @@ import { UserDto } from 'src/dto/user.dto';
 
 export interface IAuthRepository {
   /**
-   * 유저가 존재하지 않는다면 유저를 추가합니다.
-   * 유저가 기존에 존재했었다면 true를 반환합니다.
-   * 신규로 유저가 추가되었다면 false를 반환합니다.
+   * 새로운 유저를 생성합니다.
+   * 해당 유저의 normal/ladder 전적과 2차 인증 정보도 생성합니다.
    * @param user
    */
-  addUserIfNotExists(user: UserDto): Promise<[UserAuthDto, boolean]>;
+  addNewUser(user: UserDto): Promise<UserAuthDto>;
 
   /**
-   * 유저가 존재하는지 확인합니다.
-   * 존재한다면 true를 반환합니다.
-   * 존재하지 않는다면 false를 반환합니다.
+   * 유저의 ID로 인증 정보를 조회합니다.
+   * 유저가 존재한다면 유저의 인증 정보를 반환합니다.
+   * 존재하지 않는다면 null을 반환합니다.
    * @param userId
    */
-  checkUserExists(userId: number): Promise<boolean>;
+  getUserAuthInfoById(userId: number): Promise<UserAuthDto>;
+
+  /**
+   * 유저의 닉네임으로 인증 정보를 조회합니다.
+   * 유저가 존재한다면 true, 존재하지 않는다면 false를 반환합니다.
+   */
+  findUserByNickname(nickname: string): Promise<boolean>;
 
   /**
    * 2FA를 등록합니다.

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -71,16 +71,15 @@ export class UserService {
 
     const userSocketInfo = users.get(userId);
     let userStatus = UserStatus.OFFLINE;
-    if (!userSocketInfo)
-      return { ...userDto, status: userStatus } as UserDetailResponseDto;
-    if (userSocketInfo.location === 0) {
-      userStatus = UserStatus.LOBBY;
-    } else if (userSocketInfo.location < 0) {
-      userStatus = UserStatus.GAME;
-    } else if (userSocketInfo.location > 0) {
-      userStatus = UserStatus.CHAT;
+    if (userSocketInfo) {
+      if (userSocketInfo.location === 0) {
+        userStatus = UserStatus.LOBBY;
+      } else if (userSocketInfo.location < 0) {
+        userStatus = UserStatus.GAME;
+      } else if (userSocketInfo.location > 0) {
+        userStatus = UserStatus.CHAT;
+      }
     }
-
     return {
       ...userDto,
       status: userStatus,


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] BUG : 버그 수정
- [] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>중대한 사항이라면 상세히 적어주세요.
### 변경사항
/login/callback에서 유저 생성 부분에서, 
1. 자신의 인트라 아이디를 다른 유저가 닉네임으로 이미 사용하고 있을 때만 닉네임을 uuid로 사용하고,
그렇지 않을 때는 본인의 인트라 아이디로 사용하도록 수정했습니다.
2. 조건문으로 확인하는 로직이 기존에 repository에 있어, 이를 service에서 수행하도록 수정했습니다.

### 변경된 로직
1. 최초 로그인
    1. 해당 인트라 아이디를 닉네임으로 사용하고 있는 유저가 있는지 조회
        1. 없으면 해당 인트라 아이디를 그대로 닉네임으로 설정
        2. 있으면 uuid값으로 할당
    2. TwoFactorAuth, NormalStat, LadderStat 정보 Insert
    3. /lobby/?isFirstLogin=true로 리다이렉트
2. 최초 로그인 x
    1. 2차 인증을 등록한 유저라면 /2FA로 리다이렉트
